### PR TITLE
Quote '-p' argument to arachne-pnr to prevent error.

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -126,7 +126,7 @@ synth = Builder(
 # Builder: Arachne-pnr (.blif --> .asc)
 #
 pnr = Builder(
-    action='arachne-pnr -d {0} -P {1} -p {2} -o $TARGET $SOURCE'.format(
+    action='arachne-pnr -d {0} -P {1} -p "{2}" -o $TARGET $SOURCE'.format(
         env.BoardConfig().get('build.size', '1k'),
         env.BoardConfig().get('build.pack', 'tq144'),
         PCF


### PR DESCRIPTION
If there is a space in the path passed for the `-p` argument to arachne-pnr, it generates a 'too many arguments' error. This PR should fix that.